### PR TITLE
Fix text alignment in login button

### DIFF
--- a/app/ui/NavBar/Nav.tsx
+++ b/app/ui/NavBar/Nav.tsx
@@ -121,7 +121,7 @@ export default function Nav() {
                             </div>
                         ) : (
                             <button
-                                className="bg-gradient-to-r from-gray-100 to-gray-400 text-gray-700 font-semibold px-4 pr-2 rounded-full hover:from-gray-200 hover:to-gray-500 transition-all duration-200 transform hover:scale-105"
+                                className="bg-gradient-to-r from-gray-100 to-gray-400 text-gray-700 font-semibold px-4 rounded-full hover:from-gray-200 hover:to-gray-500 transition-all duration-200 transform hover:scale-105"
                                 onClick={() => router.push('/login')}
                             >
                                 Login


### PR DESCRIPTION
The issue is px-4 pr-2 - this creates asymmetric padding:

px-4 sets both left and right padding to 16px
pr-2 overrides the right padding to only 8px

This makes the text appear off-center (shifted toward the right).

Fix: Remove pr-2